### PR TITLE
게시판 API 구현 - Data REST 적용 및 테스트정의

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -22,11 +22,18 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
+
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
     compileOnly 'org.projectlombok:lombok'
+
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
+
     annotationProcessor 'org.projectlombok:lombok'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 tasks.named('test') {

--- a/project-board/src/main/java/com/study/projectboard/repository/ArticleCommentRepository.java
+++ b/project-board/src/main/java/com/study/projectboard/repository/ArticleCommentRepository.java
@@ -2,7 +2,9 @@ package com.study.projectboard.repository;
 
 import com.study.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 
 }

--- a/project-board/src/main/java/com/study/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/study/projectboard/repository/ArticleRepository.java
@@ -2,7 +2,9 @@ package com.study.projectboard.repository;
 
 import com.study.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 
 }

--- a/project-board/src/main/resources/application.yaml
+++ b/project-board/src/main/resources/application.yaml
@@ -34,8 +34,7 @@ spring:
   sql:
     init:
       mode: always
-  data:
-    rest:
+  data.rest:
       base-path: /api
       detection-strategy: annotated
 

--- a/project-board/src/test/java/com/study/projectboard/controller/DataRestTest.java
+++ b/project-board/src/test/java/com/study/projectboard/controller/DataRestTest.java
@@ -1,0 +1,80 @@
+package com.study.projectboard.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+@DisplayName("Data RestAPI 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 리스트 조회")
+    @Test
+    void givenNoting_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 조회")
+    @Test
+    void givenNoting_whenRequestingArticle_thenReturnsArticleJsonResponse() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글-> 댓글 리스트 조회")
+    @Test
+    void givenNoting_whenRequestingArticleCommentFromArticle_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 리스트 조회")
+    @Test
+    void givenNoting_whenRequestingArticleComments_thenReturnsArticleCommentsJsonResponse() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 조회")
+    @Test
+    void givenNoting_whenRequestingArticleComment_thenReturnsArticleCommentJsonResponse() throws Exception {
+        //given
+
+        //when & then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}


### PR DESCRIPTION
게시글, 댓글 데이터의 CRUD를 간편하게 Spring Data REST로 서비스하고, 해당 api들의 존재 여부만 체크하게끔 통합테스트 작성