### PR TITLE
#24 - 게시판 페이지 검색 구현

### DIFF
--- a/project-board/src/main/java/com/study/projectboard/controller/ArticleController.java
+++ b/project-board/src/main/java/com/study/projectboard/controller/ArticleController.java
@@ -38,9 +38,10 @@ public class ArticleController {
             ModelMap map) {
         Page<ArticleResponse> articles = articleService.searchArticles(searchType, searchValue, pageable).map(ArticleResponse::from);
         List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
-        System.out.println(articles.getTotalPages());
+
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers",barNumbers);
+        map.addAttribute("searchTypes",SearchType.values());
 
         return "articles/index";
     }

--- a/project-board/src/main/java/com/study/projectboard/domain/type/SearchType.java
+++ b/project-board/src/main/java/com/study/projectboard/domain/type/SearchType.java
@@ -1,5 +1,17 @@
 package com.study.projectboard.domain.type;
 
+import lombok.Getter;
+
 public enum SearchType {
-    TITLE, CONTENT, ID, NICKNAME, HASHTAG
+    TITLE("제목"),
+    CONTENT("본문"),
+    ID("유저 ID"),
+    NICKNAME("닉네임"),
+    HASHTAG("해시태그");
+
+    @Getter private final String description;
+
+    SearchType(String description) {
+        this.description = description;
+    }
 }

--- a/project-board/src/main/resources/templates/articles/index.html
+++ b/project-board/src/main/resources/templates/articles/index.html
@@ -19,13 +19,13 @@
     <div class="row">
         <div class="card card-margin search-form">
             <div class="card-body p-0">
-                <form id="card search-form">
+                <form action ="/articles" method="get">
                     <div class="row">
                         <div class="col-12">
                             <div class="row no-gutters">
                                 <div class="col-lg-3 col-md-3 col-sm-12 p-0">
                                     <label for="search-type" hidden>검색 유형</label>
-                                    <select class="form-control" id="search-type">
+                                    <select class="form-control" id="search-type" name="searchType">
                                         <option>제목</option>
                                         <option>본문</option>
                                         <option>id</option>
@@ -36,7 +36,7 @@
                                 <div class="col-lg-8 col-md-6 col-sm-12 p-0">
                                     <label for="search-value" hidden>검색어</label>
                                     <input type="text" placeholder="검색어..." class="form-control" id="search-value"
-                                           name="search-value">
+                                           name="searchValue">
                                 </div>
                                 <div class="col-lg-1 col-md-3 col-sm-12 p-0">
                                     <button type="submit" class="btn btn-base">

--- a/project-board/src/main/resources/templates/articles/index.th.xml
+++ b/project-board/src/main/resources/templates/articles/index.th.xml
@@ -3,25 +3,36 @@
     <attr sel="#header" th:replace="header :: header"/>
     <attr sel="#footer" th:replace="footer :: footer"/>
     <attr sel="main" th:object="${articles}">
-
+        <attr sel="#search-type" th:remove="all-but-first">
+            <attr sel="option[0]"
+                  th:each="searchType : ${searchTypes}"
+                  th:value="${searchType.name}"
+                  th:text="${searchType.description}"
+                  th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"/>
+        </attr>
+        <attr sel="#search-value" th:value="${param.searchValue}"/>
 
         <attr sel="#article-table">
             <attr sel="thead/tr">
                 <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles(
             page=${articles.number},
             sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : '')
+            , searchType=${param.searchType}, searchValue=${param.searchValue}
         )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
             page=${articles.number},
             sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : '')
+            , searchType=${param.searchType}, searchValue=${param.searchValue}
         )}"/>
                 <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles(
             page=${articles.number},
             sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : '')
+            , searchType=${param.searchType}, searchValue=${param.searchValue}
         )}"/>
                 <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles(
             page=${articles.number},
             sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : '')
+            , searchType=${param.searchType}, searchValue=${param.searchValue}
         )}"/>
             </attr>
 
@@ -39,20 +50,20 @@
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="'previous'"
-                  th:href="@{/articles(page=${articles.number - 1})}"
+                  th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                   th:class="'page-link' +(${articles.number} <= 0 ? ' disabled' : '')"
             />
 
             <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
                 <attr sel="a"
                       th:text="${pageNumber + 1}"
-                      th:href="@{/articles(page=${pageNumber})}"
+                      th:href="@{/articles(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
                 />
             </attr>
             <attr sel="li[2]/a"
                   th:text="'next'"
-                  th:href="@{/articles(page=${articles.number + 1})}"
+                  th:href="@{/articles(page=${articles.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                   th:class="'page-link' +(${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>

--- a/project-board/src/test/java/com/study/projectboard/controller/ArticleControllerTest.java
+++ b/project-board/src/test/java/com/study/projectboard/controller/ArticleControllerTest.java
@@ -1,6 +1,7 @@
 package com.study.projectboard.controller;
 
 import com.study.projectboard.config.SecurityConfig;
+import com.study.projectboard.domain.type.SearchType;
 import com.study.projectboard.dto.ArticleWithCommentsDto;
 import com.study.projectboard.dto.UserAccountDto;
 import com.study.projectboard.service.ArticleService;
@@ -68,7 +69,7 @@ class ArticleControllerTest {
 
     @DisplayName("[view] [GET] 게시글 리스트 (게시판) 페이지 - 페이징, 정렬 기능")
     @Test
-    void givenPagingAndSortingParams_whenRequestingArticlesPages_thenReturnsArticlesPage() throws Exception {
+    void givenPagingAndSortingParams_whenRequestingArticlesPages_thenReturnsArticlesView() throws Exception {
         // Given
         String sortName = "title";
         String direction = "desc";
@@ -95,10 +96,34 @@ class ArticleControllerTest {
 
         then(articleService).should().searchArticles(eq(null), eq(null), any(Pageable.class));
         then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
-
-
     }
 
+    @DisplayName("[view] [GET] 게시글 리스트 (게시판) 페이지 - 검색을 통한 리스트 정상 호출")
+    @Test
+    void givenSearchKeyword_whenSearchingArticlesPages_thenReturnsArticlesView() throws Exception {
+        // Given
+        SearchType searchType = SearchType.TITLE;
+        String searchValue ="title";
+
+        given(articleService.searchArticles(eq(searchType), eq(searchValue), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(),anyInt())).willReturn(List.of(0,1,2,3,4));
+
+        //When & Then
+        mvc.perform(
+                        get("/articles")
+                                .queryParam("searchType", searchType.name())
+                                .queryParam("searchValue", searchValue)
+
+                )
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(view().name("articles/index"))
+                .andExpect(model().attributeExists("articles"))
+                .andExpect(model().attributeExists("searchTypes"));
+
+        then(articleService).should().searchArticles(eq(searchType), eq(searchValue), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(), anyInt());
+    }
     @DisplayName("[view] [GET] 게시글 상세 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingArticleView_thenReturnsArticleView() throws Exception {


### PR DESCRIPTION
- 1a47bae
게시판 페이지의 검색에서 검색 종류를 드롭 다운 메뉴로 전달 시 
해당 종류들을 view에서 넣는 것이아닌 서버로부터 받아 쓰게하게 함 
=>  model에 검색 타입 옵션 전달
* 해당 검색 기능 구현 및 테스트 완료

- 4b76153
게시판 페이 지의 검색바에서 검색을 하기 위한 view 템플릿 구현