### PR TITLE
헤더에 해시태그 메뉴 추가

### DIFF
--- a/project-board/src/main/resources/templates/articles/header.th.xml
+++ b/project-board/src/main/resources/templates/articles/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}"/>
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}"/>
+</thlogic>

--- a/project-board/src/main/resources/templates/header.html
+++ b/project-board/src/main/resources/templates/header.html
@@ -9,7 +9,8 @@
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtag</a></li>
             </ul>
 
             <div class="text-end">


### PR DESCRIPTION
개요
페이지 헤더에 해시태그-검색 페이지로 이동할 수있는 메뉴를 추가

구현
페이지 접속 링크는 타임리프 태그로 처리하도록 변경
=> 정적 목업페이지에 링크 동작을 보여주지 않아 리소스 접근에 안전하다.

This closes #36 