### PR TITLE
헤로쿠 DB 변경 :  ClearDB -> JawsDB

### DIFF
--- a/project-board/src/main/resources/application.yaml
+++ b/project-board/src/main/resources/application.yaml
@@ -46,7 +46,8 @@ spring:
     activate:
       on-profile: heroku
   datasource:
-    url: ${CLEARDB_DATABASE_URL}
+    url: ${JAWSDB_URL}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
프로젝트 때 설정한 `8` 버전을 ClearDB 에서 지원하지 않기 때문에 JawsDB로 변경 {`article_comment_content` index size로 인한 변경}
This fixes #44 