### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode() 비교 시 getter 적용

### DIFF
--- a/src/main/java/com/study/projectboard/domain/Article.java
+++ b/src/main/java/com/study/projectboard/domain/Article.java
@@ -54,6 +54,7 @@ public class Article extends AuditingFields {
         return new Article(userAccount, title, content, hashtag);
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/com/study/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/study/projectboard/domain/ArticleComment.java
@@ -47,11 +47,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.getId());
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/study/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/study/projectboard/domain/UserAccount.java
@@ -49,11 +49,11 @@ public class UserAccount extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && userId.equals(that.getUserId());
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
equals, hashcode 비교 시 필드에 직접 접근하여
비교하면 lazyloading 시 
필드 값이 `null`일 수 있음 이를 예방하기 위해
getter를 통해 해당 인스턴스의 필드 값에 접근하도록 변경함

This closes #51 